### PR TITLE
Correct Error Calculation in Test Script

### DIFF
--- a/makefile
+++ b/makefile
@@ -60,7 +60,7 @@ $(LIB): $(OBJECTS)
 	$(AR) $(ARFLAGS) $(LIB) $^
 
 test: $(EXECUTABLE)
-	./$(EXECUTABLE) data/zort_111_160_15.dat data/zort_111_160_15.mgard  11 160 15 1e-3 0
+	./$(EXECUTABLE) data/zort_111_160_15.dat data/zort_111_160_15.mgard 111 160 15 1e-3 0
 
 test2: $(EXECUTABLE)
 	./$(EXECUTABLE) data/u3_513x513_orig data/u3_513x513.mgard   513  513 1  1e-3 0


### PR DESCRIPTION
These commits make various changes to the test script `src/mgard_test.c`, the most significant of which are the correction of the calculation of the L^∞ error and the addition of a help message. Please check that my description of the parameters in the help message is correct.