### PR TITLE
Run Workflows on Pull Requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: [push]
+on: [push, pull_request]
 env:
         MOAB_CACHE_KEY: "MOAB-5.2.1"
         MOAB_INSTALL_PREFIX: "${{ github.workspace }}/moab"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,5 +1,5 @@
 name: format
-on: [push]
+on: [push, pull_request]
 env:
         RCF_REPO_DIR: "run-clang-format"
         MGARD_REPO_DIR: "MGARD"


### PR DESCRIPTION
This commit configures the `format` and `build` workflows to run on pull requests. They might not run on *this* pull request – I think it's the configuration of the base branch, not the head branch, that is used. I tested the new configuration by opening a test pull request (#138) onto `pull-request-workflows`, the head branch here. The workflows did run, and you can see the results [here][workflow results]. They aren't currently showing up in the pull request itself, possibly because I deleted the head branch of that request. 

[workflow results]: https://github.com/CODARcode/MGARD/pull/138/checks