### PR TITLE
Record Whether Node Coordinates Manually Specified

### DIFF
--- a/include/TensorMeshHierarchy.hpp
+++ b/include/TensorMeshHierarchy.hpp
@@ -86,6 +86,14 @@ public:
   //! Coordinates of the nodes in the finest mesh.
   std::array<std::vector<Real>, N> coordinates;
 
+  //! Whether the mesh on the finest level is the default one (nodes uniformly
+  //! spaced on `[0, 1]` in each dimension).
+  //!
+  //!\note If the default mesh is manually passed to the constructor, this flag
+  //! will be set to `false`. Manually passed meshes are not checked for
+  //! equality with the default mesh.
+  bool uniform;
+
   //! Index of finest mesh.
   std::size_t L;
 

--- a/include/TensorMeshHierarchy.tpp
+++ b/include/TensorMeshHierarchy.tpp
@@ -38,7 +38,7 @@ template <std::size_t N, typename Real>
 TensorMeshHierarchy<N, Real>::TensorMeshHierarchy(
     const std::array<std::size_t, N> &shape,
     const std::array<std::vector<Real>, N> &coordinates)
-    : coordinates(coordinates) {
+    : coordinates(coordinates), uniform(false) {
   for (std::size_t i = 0; i < N; ++i) {
     if (coordinates.at(i).size() != shape.at(i)) {
       throw std::invalid_argument("incorrect number of node coordinates given");
@@ -159,7 +159,9 @@ default_node_coordinates(const std::array<std::size_t, N> &shape) {
 template <std::size_t N, typename Real>
 TensorMeshHierarchy<N, Real>::TensorMeshHierarchy(
     const std::array<std::size_t, N> &shape)
-    : TensorMeshHierarchy(shape, default_node_coordinates<N, Real>(shape)) {}
+    : TensorMeshHierarchy(shape, default_node_coordinates<N, Real>(shape)) {
+  uniform = true;
+}
 
 template <std::size_t N, typename Real>
 bool operator==(const TensorMeshHierarchy<N, Real> &a,

--- a/tests/src/test_TensorMeshHierarchy.cpp
+++ b/tests/src/test_TensorMeshHierarchy.cpp
@@ -51,6 +51,7 @@ TEST_CASE("hierarchy mesh shapes", "[TensorMeshHierarchy]") {
 TEST_CASE("TensorMeshHierarchy construction", "[TensorMeshHierarchy]") {
   {
     const mgard::TensorMeshHierarchy<1, float> hierarchy({17});
+    REQUIRE(hierarchy.uniform);
     REQUIRE(hierarchy.L == 4);
     std::vector<std::size_t> ndofs(hierarchy.L + 1);
     for (std::size_t l = 0; l <= hierarchy.L; ++l) {
@@ -62,6 +63,7 @@ TEST_CASE("TensorMeshHierarchy construction", "[TensorMeshHierarchy]") {
   }
   {
     const mgard::TensorMeshHierarchy<2, double> hierarchy({12, 39});
+    REQUIRE(hierarchy.uniform);
     REQUIRE(hierarchy.L == 4);
     std::vector<std::size_t> ndofs(hierarchy.L + 1);
     for (std::size_t l = 0; l <= hierarchy.L; ++l) {
@@ -90,6 +92,7 @@ TEST_CASE("TensorMeshHierarchy construction", "[TensorMeshHierarchy]") {
   }
   {
     const mgard::TensorMeshHierarchy<3, double> hierarchy({15, 6, 129});
+    REQUIRE(hierarchy.uniform);
     REQUIRE(hierarchy.L == 3);
     // Note that the final dimension doesn't begin decreasing until every index
     // is of the form `2^k + 1`.
@@ -100,6 +103,7 @@ TEST_CASE("TensorMeshHierarchy construction", "[TensorMeshHierarchy]") {
   {
     const mgard::TensorMeshHierarchy<3, float> hierarchy(
         {5, 3, 2}, {{{0.0, 0.5, 0.75, 1.0, 1.25}, {-3, -2, -1}, {10.5, 9.5}}});
+    REQUIRE(not hierarchy.uniform);
     REQUIRE_NOTHROW(hierarchy);
   }
   {


### PR DESCRIPTION
This commit adds a data member `uniform` to `TensorMeshHierarchy`. `uniform` will be `false` iff the `TensorMeshHierarchy` was created with the constructor taking manually specified node coordinates.