### PR TITLE
Fix pointer type mismatch with decompress_memory_z

### DIFF
--- a/include/compress.tpp
+++ b/include/compress.tpp
@@ -415,7 +415,7 @@ DecompressedDataset<N, Real> decompress(
   // TODO: Figure out all these casts here and above.
 #ifndef MGARD_ZSTD
   decompress_memory_z(const_cast<void *>(compressed.data()), compressed.size(),
-                      reinterpret_cast<int *>(quantized),
+                      reinterpret_cast<unsigned char *>(quantized),
                       ndof * sizeof(*quantized));
 #else
   decompress_memory_huffman(

--- a/include/compressors.hpp
+++ b/include/compressors.hpp
@@ -62,7 +62,7 @@ void compress_memory_z(void *const in_data, const std::size_t in_data_size,
 //!\param dst Decompressed array.
 //!\param dstLen Size in bytes of the decompressed array.
 void decompress_memory_z(void *const src, const std::size_t srcLen,
-                         int *const dst, const std::size_t dstLen);
+                         unsigned char *const dst, const std::size_t dstLen);
 
 } // namespace mgard
 

--- a/src/compressors.cpp
+++ b/src/compressors.cpp
@@ -608,7 +608,7 @@ void compress_memory_z(void *const in_data, const std::size_t in_data_size,
 }
 
 void decompress_memory_z(void *const src, const std::size_t srcLen,
-                         int *const dst, const std::size_t dstLen) {
+                         unsigned char *const dst, const std::size_t dstLen) {
   z_stream strm = {};
   strm.total_in = strm.avail_in = srcLen;
   strm.total_out = strm.avail_out = dstLen;


### PR DESCRIPTION
The `decompress_memory_z` function took an `int*` for the array of
its destination. However, there were instances in the code that
were trying to give it an `unsigned char*` (probably because
that is the destination array type for the sister function
`decompress_memory_zstd`).

Change the destination argument to `unsigned char*`. This makes
the array type more consistent between the two decompress_memory
function. It also matches better with the `dstLen` argument,
which measures the length of the array in bytes.