### PR TITLE
Head Off NVCC Bug

### DIFF
--- a/include/compress.hpp
+++ b/include/compress.hpp
@@ -13,6 +13,11 @@
 
 #include <memory>
 
+#ifdef __NVCC__
+#error "Please include `compress_cuda.hpp` instead of `compress.hpp` when "\
+  "compiling with NVCC."
+#endif
+
 #include "compress_cuda.hpp"
 
 //! Implementation of the MGARD compression and decompression algorithms.


### PR DESCRIPTION
See #126 and #160. This commit adds a check to prevent NVCC from including `compress.hpp` while we wait for the NVCC preprocessor bug to be fixed.