### PR TITLE
Rebased #168

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,10 @@ option(MGARD_ENABLE_DOCS "Build documentation." OFF)
 
 option(MGARD_ENABLE_OPENMP "Enable OpenMP support." OFF)
 option(MGARD_ENABLE_CUDA "Enable CUDA support" OFF)
+option(MGARD_ENABLE_CUDA_FMA "Enable CUDA support with fused multiply–add instruction." OFF)
 option(MGARD_ENABLE_SERIAL "Enable SERIAL support" OFF)
 option(MGARD_ENABLE_HIP "Enable HIP support" OFF)
 option(MGARD_ENABLE_KOKKOS "Enable Kokkos support" OFF)
-
-#For performance optimization
-option(MGARD_ENABLE_CUDA_FMA "Enable CUDA support with fused multiply–add instruction." OFF)
-option(MGARD_ENABLE_CUDA_OPTIMIZE_VOLTA "Optimize for Volta GPUs." OFF)
-option(MGARD_ENABLE_CUDA_OPTIMIZE_TURING "Optimize for Turing GPUs." OFF)
 
 option(MGARD_ENABLE_CLI "Build executable." OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,10 +115,14 @@ if (MGARD_ENABLE_SERIAL OR
                                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 endif()
 
+#Adding library here so we can set compile definitions for it.
+add_library(mgard-library)
+
 if(MGARD_ENABLE_SERIAL)
   set (CMAKE_CXX_STANDARD 14)
   set (CMAKE_CXX_STANDARD_REQUIRED ON)
-  set (CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DMGARD_ENABLE_SERIAL -w")
+  target_compile_definitions(mgard-library PUBLIC MGARD_ENABLE_SERIAL)
+  set (CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -w")
 endif()
 
 if(MGARD_ENABLE_CUDA)
@@ -143,18 +147,15 @@ if(MGARD_ENABLE_CUDA)
     target_include_directories(MgardCudaExec PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 
-  set (CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DMGARD_ENABLE_CUDA")
-  set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DMGARD_ENABLE_CUDA")
+  target_compile_definitions(mgard-library PUBLIC MGARD_ENABLE_CUDA)
   set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr -w")
   
   set (MGARD_X_SEPARATE_COMPILE_COMPILATION_OPTION 
        CUDA_SEPARABLE_COMPILATION ON)
 
   if(MGARD_ENABLE_CUDA_FMA)
-    set (CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DMGARD_X_FMA")
-    set (CMAKE_CUDA_FLAGS  "${CMAKE_CUDA_FLAGS} -DMGARD_X_FMA")
-    set (CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DMGARD_CUDA_FMA")
-    set (CMAKE_CUDA_FLAGS  "${CMAKE_CUDA_FLAGS} -DMGARD_CUDA_FMA")
+    target_compile_definitions(mgard-library PUBLIC MGARD_X_FMA)
+    target_compile_definitions(mgard-library PUBLIC MGARD_CUDA_FMA)
   endif()
 endif()
 
@@ -164,7 +165,8 @@ if (MGARD_ENABLE_HIP)
   enable_language(HIP)
   set (CMAKE_CXX_STANDARD 14)
   set (CMAKE_CXX_STANDARD_REQUIRED ON)
-  set (CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DMGARD_ENABLE_HIP -w")
+  target_compile_definitions(mgard-library PUBLIC MGARD_ENABLE_HIP)
+  set (CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -w")
 endif()
 
 if (MGARD_ENABLE_KOKKOS)
@@ -257,8 +259,9 @@ list(APPEND MGARD_LIBRARY_CPP "${MGARD_COMPRESS_INTERNAL_CPP}")
 #See <https://github.com/protocolbuffers/protobuf/issues/2032>.
 set_source_files_properties("${MGARD_FILE_FORMAT_CPP}" PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 
-add_library(
+target_sources(
   mgard-library
+  PRIVATE
   ${MGARD_LIBRARY_CPP}
   ${MGARD_CUDA_SRC}
   ${MGARD_X_SRC}

--- a/include/TensorLinearOperator.hpp
+++ b/include/TensorLinearOperator.hpp
@@ -1,8 +1,11 @@
 #ifndef TENSORLINEAROPERATOR_HPP
 #define TENSORLINEAROPERATOR_HPP
+// clang-format off
+// disable formatting here because the formula below breaks the parser in NVCC
+// sometimes if it is split onto multiple lines
 //!\file
-//!\brief Base class for representing linear operators \f$R^{N_{1}} \otimes
-//! \cdots \otimes R^{N_{d}} \to R^{N_{1}} \otimes \cdots \otimes R^{N_{d}}\f$.
+//!\brief Base class for representing linear operators \f$R^{N_{1}} \otimes \cdots \otimes R^{N_{d}} \to R^{N_{1}} \otimes \cdots \otimes R^{N_{d}}\f$.
+// clang-format on
 
 #include <cstddef>
 

--- a/include/cli/arguments.hpp
+++ b/include/cli/arguments.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include <limits>
 #include <string>
 #include <vector>
 

--- a/include/cli/cmdline.hpp
+++ b/include/cli/cmdline.hpp
@@ -3,6 +3,7 @@
 //!\file
 //!\brief Parsers for the executable command line interface.
 
+#include <limits>
 #include <list>
 #include <map>
 #include <string>

--- a/src/cli/cmdline.cpp
+++ b/src/cli/cmdline.cpp
@@ -129,7 +129,7 @@ std::vector<std::string>
 subcommandNames(const std::map<std::string, SubCmdLine *> &subcommands) {
   std::vector<std::string> names;
   names.reserve(subcommands.size());
-  for (const std::pair<const std::string, SubCmdLine *> pair : subcommands) {
+  for (const std::pair<const std::string, SubCmdLine *> &pair : subcommands) {
     names.push_back(pair.first);
   }
   return names;


### PR DESCRIPTION
This pull request contains three commits. The first and second are the result of rebasing the commits in #168 onto 4aa36000ead52795b9154b324180df24d013b41b. The third removes two obsolete CMake options (see [Jieyang's comment][Jieyang's comment] on #168).

[Jieyang's comment]: https://github.com/CODARcode/MGARD/pull/168#issuecomment-1057414287