### PR TITLE
Replace `SIGNATURE` with `mgard::SIGNATURE`

### DIFF
--- a/include/format.hpp
+++ b/include/format.hpp
@@ -11,7 +11,16 @@
 
 #include "proto/mgard.pb.h"
 
+#ifdef __NVCC__
+// NVCC breaks on `utilities.hpp`. See (we think) <https://github.com/CODARcode/
+// MGARD/issues/126> and <https://forums.developer.nvidia.com/t/
+// nvcc-preprocessor-bug-causes-compilation-failure/65962>.
+
+//! Forward declaration.
+template <typename T> struct MemoryBuffer;
+#else
 #include "utilities.hpp"
+#endif
 
 namespace mgard {
 

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -14,6 +14,11 @@
 
 #include "MGARDConfig.hpp"
 
+#ifdef __NVCC__
+// `utilities.hpp` wasn't included in the header.
+#include "utilities.hpp"
+#endif
+
 namespace mgard {
 
 std::uint_least64_t deserialize_header_size(


### PR DESCRIPTION
This commit replaces the signature macro defined in `include/mgard-x/Metadata.hpp` with the `mgard::SIGNATURE` constant defined in `include/format.hpp`.

@JieyangChen7, please review this commit. In addition to the signature switch, it also removes the `Metadata::signature` data member (since the only valid value is `mgard::SIGNATURE`). I can keep that member if you prefer.

@qliu21, please don't merge this pull request yet. I'll rebase on top of `fix-installation-paths` once you merge #194.