### PR TITLE
Fix issue with MGARDXConfig.h in installed headers

### DIFF
--- a/include/compress_x.hpp
+++ b/include/compress_x.hpp
@@ -5,7 +5,6 @@
  * Date: March 17, 2022
  */
 
-#include "MGARDXConfig.h"
 #include "mgard-x/RuntimeX/RuntimeXPublic.h"
 #include "mgard-x/Utilities/Types.h"
 #include <cstdint>

--- a/include/mgard-x/RuntimeX/RuntimeX.h
+++ b/include/mgard-x/RuntimeX/RuntimeX.h
@@ -5,8 +5,6 @@
  * Date: March 17, 2022
  */
 
-#include "MGARDXConfig.h"
-
 #include "RuntimeXPublic.h"
 
 #include "DataTypes.h"

--- a/include/mgard-x/RuntimeX/RuntimeXPublic.h
+++ b/include/mgard-x/RuntimeX/RuntimeXPublic.h
@@ -4,6 +4,8 @@
  * Author: Jieyang Chen (chenj3@ornl.gov)
  * Date: March 17, 2022
  */
+#include "MGARDXConfig.h"
+
 #include "DataTypes.h"
 
 #include "DataStructures/Array.h"


### PR DESCRIPTION
When compiling software outside of MGARD that is linking against the
install directory, including `compress_x.hpp` resulted in a compiler
error because it could not find `MGARDXConfig.h`

The problem is that `MGARDXConfig.h` is a generated header that is
initially placed in the root include directory and then copied to the
`mgard-x/RuntimeX` subdirectory in the install. So, when compiling
against the build directory, the location (w.r.t. `compress_x.hpp`) is
the local directory, but when compiling against the install directory,
the location is in the `mgard-x/RuntimeX`.

You would think the solution would be to change the install location so
that the directory would be constant. However, that breaks an include
from another file, `mgard-x/RuntimeX/RuntimeX.h`. Because
`MGARDXConfig.h` is created in the build directory, it is included as
`#include "MGARDXConfig.h"` from anywhere in the source directory. So,
if you moved changed the install location of `MGARDXConfig.h`, that
would break the `RuntimeX.h` include.

To fix this issue, I changed the inclusion of `MGARDXConfig.h` to only
come from one file. `MGARDXConfig.h` is only included from
`compress_x.hpp` and `RuntimeX.h`. Both of these files include
`RuntimeXPublic.h`. So, a simple solution is to move the inclusion of
`MGARDXConfig.h` there.