### PR TITLE
Add descriptions of hierarchy parameters

### DIFF
--- a/include/mgard-x/Hierarchy/Hierarchy.h
+++ b/include/mgard-x/Hierarchy/Hierarchy.h
@@ -72,16 +72,40 @@ template <DIM D, typename T, typename DeviceType> struct Hierarchy {
   /* Refactoring env */
   // enum device_type dev_type;
   // int dev_id;
+  /// Target number of levels in the hierarchy.
   SIZE l_target;
+  /// A padded version of the number of dimensions. This will always be as big
+  /// as `D` or larger. It will also always be 3 or larger. If `D` is even,
+  /// one is added to make `D_padded` odd.
   DIM D_padded;
+  /// The size of each dimension. The length of this array is `D`.
   std::vector<SIZE> shape_org;
+  /// The size of each dimension in reverse (k,j,i) order. The length of this
+  /// array is `D`. This is the same as `shape_org` except in reverse order.
   std::vector<SIZE> shape;
+  /// The degrees of freedom (i.e., number of values) along each dimension for
+  /// each level. the length of the outer vector is `D`, and the length of
+  /// each inner vector is `l_target`.
   std::vector<std::vector<SIZE>> dofs;
+  /// For each level, the shape of the data at that point in the hierarchy.
+  /// The outer vector is of size `l_target + 1`. Each inner array is of
+  /// size `D_padded`.
   std::vector<Array<1, SIZE, DeviceType>> shapes;
+  /// Same as `shapes` but used on the host instead of the device.
   std::vector<std::vector<SIZE>> shapes2;
+  /// The degrees of freedom along each dimension for each level. This array
+  /// has the same information as `dofs` with the following exceptions:
+  /// 1. The 2D data is flattened into a single array so that it can be
+  ///    accessed on the device.
+  /// 2. The level order is reversed.
+  /// 3. The levels are padded with a 0 value at the beginning.
   Array<1, SIZE, DeviceType> ranges;
+  /// An array of coordinates along each dimension. The vector is of size
+  /// `D`. Each array should be the size of the associated dimension.
   std::vector<T *> coords_h; // do not copy this
   // std::vector<T *> coords_d;
+  /// An array of coordinates along each dimension. The vector is of size
+  /// `D`. Each array should be the size of the associated dimension.
   std::vector<Array<1, T, DeviceType>> coords;
 
   std::vector<std::vector<Array<1, T, DeviceType>>> dist_array;


### PR DESCRIPTION
When looking at MGARD's source code, it is helpful to have a description
of exactly what each of the parameters of the `Hierarchy` object mean.
Added several comments that give brief descriptions for most of the
parameters.