### PR TITLE
Update crusher build to ROCm 5.1.0

### DIFF
--- a/build_scripts/build_mgard_hip_crusher.sh
+++ b/build_scripts/build_mgard_hip_crusher.sh
@@ -9,7 +9,7 @@
 set -e
 set -x
 
-module load rocm/4.5.2
+module load rocm/5.1.0
 module load cmake
 
 ######## User Configurations ########


### PR DESCRIPTION
The build_mgard_hip_crusher.sh script was building mgard-x with
an old version of ROCm. Although this worked, it could be
problematic for code using a newer version. Update to build
with ROCm 5.1.0, which is newer and currently the default version
on crusher.