### PR TITLE
Fix ambiguous overloads

### DIFF
--- a/include/mgard-x/DataRefactoring/DataRefactor.hpp
+++ b/include/mgard-x/DataRefactoring/DataRefactor.hpp
@@ -39,7 +39,8 @@ public:
     size_t workspace_size = 1;
     for (DIM d = 0; d < D; d++) {
       if (d == D - 1) {
-        workspace_size *= roundup((shape[d] + 2) * sizeof(T), pitch_size);
+        workspace_size *=
+            roundup((size_t)(shape[d] + 2) * sizeof(T), pitch_size);
       } else {
         workspace_size *= shape[d] + 2;
       }

--- a/include/mgard-x/DataRefactoring/MultiDimension/Coefficient/CalcCoefficientsPointers.hpp
+++ b/include/mgard-x/DataRefactoring/MultiDimension/Coefficient/CalcCoefficientsPointers.hpp
@@ -36,48 +36,48 @@ void CalcCoefficientsPointers(
   dcoarse.resize(curr_dims[2], nn[2]);
 
   dcoeff_r = doutput;
-  dcoeff_r.offset(curr_dims[0], nn[0]);
+  dcoeff_r.offset_dim(curr_dims[0], nn[0]);
   dcoeff_r.resize(curr_dims[0], n[0] - nn[0]);
   dcoeff_r.resize(curr_dims[1], nn[1]);
   dcoeff_r.resize(curr_dims[2], nn[2]);
 
   dcoeff_c = doutput;
-  dcoeff_c.offset(curr_dims[1], nn[1]);
+  dcoeff_c.offset_dim(curr_dims[1], nn[1]);
   dcoeff_c.resize(curr_dims[0], nn[0]);
   dcoeff_c.resize(curr_dims[1], n[1] - nn[1]);
   dcoeff_c.resize(curr_dims[2], nn[2]);
 
   dcoeff_f = doutput;
-  dcoeff_f.offset(curr_dims[2], nn[2]);
+  dcoeff_f.offset_dim(curr_dims[2], nn[2]);
   dcoeff_f.resize(curr_dims[0], nn[0]);
   dcoeff_f.resize(curr_dims[1], nn[1]);
   dcoeff_f.resize(curr_dims[2], n[2] - nn[2]);
 
   dcoeff_rc = doutput;
-  dcoeff_rc.offset(curr_dims[0], nn[0]);
-  dcoeff_rc.offset(curr_dims[1], nn[1]);
+  dcoeff_rc.offset_dim(curr_dims[0], nn[0]);
+  dcoeff_rc.offset_dim(curr_dims[1], nn[1]);
   dcoeff_rc.resize(curr_dims[0], n[0] - nn[0]);
   dcoeff_rc.resize(curr_dims[1], n[1] - nn[1]);
   dcoeff_rc.resize(curr_dims[2], nn[2]);
 
   dcoeff_rf = doutput;
-  dcoeff_rf.offset(curr_dims[0], nn[0]);
-  dcoeff_rf.offset(curr_dims[2], nn[2]);
+  dcoeff_rf.offset_dim(curr_dims[0], nn[0]);
+  dcoeff_rf.offset_dim(curr_dims[2], nn[2]);
   dcoeff_rf.resize(curr_dims[0], n[0] - nn[0]);
   dcoeff_rf.resize(curr_dims[1], nn[1]);
   dcoeff_rf.resize(curr_dims[2], n[2] - nn[2]);
 
   dcoeff_cf = doutput;
-  dcoeff_cf.offset(curr_dims[1], nn[1]);
-  dcoeff_cf.offset(curr_dims[2], nn[2]);
+  dcoeff_cf.offset_dim(curr_dims[1], nn[1]);
+  dcoeff_cf.offset_dim(curr_dims[2], nn[2]);
   dcoeff_cf.resize(curr_dims[0], nn[0]);
   dcoeff_cf.resize(curr_dims[1], n[1] - nn[1]);
   dcoeff_cf.resize(curr_dims[2], n[2] - nn[2]);
 
   dcoeff_rcf = doutput;
-  dcoeff_rcf.offset(curr_dims[0], nn[0]);
-  dcoeff_rcf.offset(curr_dims[1], nn[1]);
-  dcoeff_rcf.offset(curr_dims[2], nn[2]);
+  dcoeff_rcf.offset_dim(curr_dims[0], nn[0]);
+  dcoeff_rcf.offset_dim(curr_dims[1], nn[1]);
+  dcoeff_rcf.offset_dim(curr_dims[2], nn[2]);
   dcoeff_rcf.resize(curr_dims[0], n[0] - nn[0]);
   dcoeff_rcf.resize(curr_dims[1], n[1] - nn[1]);
   dcoeff_rcf.resize(curr_dims[2], n[2] - nn[2]);

--- a/include/mgard-x/DataRefactoring/MultiDimension/Correction/CalcCorrectionND.hpp
+++ b/include/mgard-x/DataRefactoring/MultiDimension/Correction/CalcCorrectionND.hpp
@@ -53,7 +53,7 @@ void CalcCorrectionND(Hierarchy<D, T, DeviceType> &hierarchy,
   curr_dim_f = D - 1, curr_dim_c = D - 2, curr_dim_r = D - 3;
 
   dw_in1.resize(curr_dim_f, hierarchy.level_shape(l - 1, curr_dim_f));
-  dw_in2.offset(curr_dim_f, hierarchy.level_shape(l - 1, curr_dim_f));
+  dw_in2.offset_dim(curr_dim_f, hierarchy.level_shape(l - 1, curr_dim_f));
   dw_in2.resize(curr_dim_f, hierarchy.level_shape(l, curr_dim_f) -
                                 hierarchy.level_shape(l - 1, curr_dim_f));
   dw_out.resize(curr_dim_f, hierarchy.level_shape(l - 1, curr_dim_f));
@@ -86,10 +86,10 @@ void CalcCorrectionND(Hierarchy<D, T, DeviceType> &hierarchy,
 
   curr_dim_f = D - 1, curr_dim_c = D - 2, curr_dim_r = D - 3;
   dw_in1.resize(curr_dim_c, hierarchy.level_shape(l - 1, curr_dim_c));
-  dw_in2.offset(curr_dim_c, hierarchy.level_shape(l - 1, curr_dim_c));
+  dw_in2.offset_dim(curr_dim_c, hierarchy.level_shape(l - 1, curr_dim_c));
   dw_in2.resize(curr_dim_c, hierarchy.level_shape(l, curr_dim_c) -
                                 hierarchy.level_shape(l - 1, curr_dim_c));
-  dw_out.offset(prev_dim_f, hierarchy.level_shape(l - 1, curr_dim_f));
+  dw_out.offset_dim(prev_dim_f, hierarchy.level_shape(l - 1, curr_dim_f));
   dw_out.resize(curr_dim_c, hierarchy.level_shape(l - 1, curr_dim_c));
   prev_dim_f = curr_dim_f;
   prev_dim_c = curr_dim_c;
@@ -120,10 +120,10 @@ void CalcCorrectionND(Hierarchy<D, T, DeviceType> &hierarchy,
 
   curr_dim_f = D - 1, curr_dim_c = D - 2, curr_dim_r = D - 3;
   dw_in1.resize(curr_dim_r, hierarchy.level_shape(l - 1, curr_dim_r));
-  dw_in2.offset(curr_dim_r, hierarchy.level_shape(l - 1, curr_dim_r));
+  dw_in2.offset_dim(curr_dim_r, hierarchy.level_shape(l - 1, curr_dim_r));
   dw_in2.resize(curr_dim_r, hierarchy.level_shape(l, curr_dim_r) -
                                 hierarchy.level_shape(l - 1, curr_dim_r));
-  dw_out.offset(prev_dim_c, hierarchy.level_shape(l - 1, curr_dim_c));
+  dw_out.offset_dim(prev_dim_c, hierarchy.level_shape(l - 1, curr_dim_c));
   dw_out.resize(curr_dim_r, hierarchy.level_shape(l - 1, curr_dim_r));
   prev_dim_f = curr_dim_f;
   prev_dim_c = curr_dim_c;
@@ -155,10 +155,10 @@ void CalcCorrectionND(Hierarchy<D, T, DeviceType> &hierarchy,
 
     curr_dim_f = D - 1, curr_dim_c = D - 2, curr_dim_r = D - (i + 1);
     dw_in1.resize(curr_dim_r, hierarchy.level_shape(l - 1, curr_dim_r));
-    dw_in2.offset(curr_dim_r, hierarchy.level_shape(l - 1, curr_dim_r));
+    dw_in2.offset_dim(curr_dim_r, hierarchy.level_shape(l - 1, curr_dim_r));
     dw_in2.resize(curr_dim_r, hierarchy.level_shape(l, curr_dim_r) -
                                   hierarchy.level_shape(l - 1, curr_dim_r));
-    dw_out.offset(prev_dim_r, hierarchy.level_shape(l - 1, prev_dim_r));
+    dw_out.offset_dim(prev_dim_r, hierarchy.level_shape(l - 1, prev_dim_r));
     dw_out.resize(curr_dim_r, hierarchy.level_shape(l - 1, curr_dim_r));
     prev_dim_f = curr_dim_f;
     prev_dim_c = curr_dim_c;

--- a/include/mgard-x/DataRefactoring/MultiDimension/Correction/IterativeProcessingKernel.hpp
+++ b/include/mgard-x/DataRefactoring/MultiDimension/Correction/IterativeProcessingKernel.hpp
@@ -127,7 +127,7 @@ public:
 
     // T *vec = v + get_idx(ldv1, ldv2, r_gl, c_gl, 0);
 
-    v.offset(r_gl, c_gl, 0);
+    v.offset_3d(r_gl, c_gl, 0);
 
     prev_vec_sm = 0.0;
 
@@ -697,7 +697,7 @@ public:
     r_sm = FunctorBase<DeviceType>::GetThreadIdY();
     c_sm = FunctorBase<DeviceType>::GetThreadIdX();
 
-    v.offset(r_gl, 0, f_gl);
+    v.offset_3d(r_gl, 0, f_gl);
     // T *vec = v + get_idx(ldv1, ldv2, r_gl, 0, f_gl);
 
     prev_vec_sm = 0.0;
@@ -1360,7 +1360,7 @@ public:
     c_sm = FunctorBase<DeviceType>::GetThreadIdY();
     r_sm = FunctorBase<DeviceType>::GetThreadIdX();
 
-    v.offset(0, c_gl, f_gl);
+    v.offset_3d(0, c_gl, f_gl);
     // T *vec = v + get_idx(ldv1, ldv2, 0, c_gl, f_gl);
 
     prev_vec_sm = 0.0;

--- a/include/mgard-x/DataRefactoring/MultiDimension/Correction/IterativeProcessingKernel3D.hpp
+++ b/include/mgard-x/DataRefactoring/MultiDimension/Correction/IterativeProcessingKernel3D.hpp
@@ -42,7 +42,7 @@ public:
     r_sm = FunctorBase<DeviceType>::GetThreadIdY();
     f_sm = FunctorBase<DeviceType>::GetThreadIdX();
 
-    v.offset(r_gl, c_gl, 0);
+    v.offset_3d(r_gl, c_gl, 0);
     T *sm = (T *)FunctorBase<DeviceType>::GetSharedMemory();
     ldsm1 = F + G;
     ldsm2 = C;
@@ -432,7 +432,7 @@ public:
     r_sm = FunctorBase<DeviceType>::GetThreadIdY();
     c_sm = FunctorBase<DeviceType>::GetThreadIdX();
 
-    v.offset(r_gl, 0, f_gl);
+    v.offset_3d(r_gl, 0, f_gl);
     T *sm = (T *)FunctorBase<DeviceType>::GetSharedMemory();
     ldsm1 = F;
     ldsm2 = C + G;
@@ -806,7 +806,7 @@ public:
     c_sm = FunctorBase<DeviceType>::GetThreadIdY();
     r_sm = FunctorBase<DeviceType>::GetThreadIdX();
 
-    v.offset(0, c_gl, f_gl);
+    v.offset_3d(0, c_gl, f_gl);
     T *sm = (T *)FunctorBase<DeviceType>::GetSharedMemory();
     ldsm1 = F;
     ldsm2 = C;

--- a/include/mgard-x/DataRefactoring/SingleDimension/DataRefactoring.hpp
+++ b/include/mgard-x/DataRefactoring/SingleDimension/DataRefactoring.hpp
@@ -70,7 +70,7 @@ void decompose_single(Hierarchy<D, T, DeviceType> &hierarchy,
       SubArray<D, T, DeviceType> coarse = v;
       coarse.resize(coarse_shape);
       SubArray<D, T, DeviceType> coeff = v;
-      coeff.offset(curr_dim, hierarchy.level_shape(l - 1, curr_dim));
+      coeff.offset_dim(curr_dim, hierarchy.level_shape(l - 1, curr_dim));
       coeff.resize(coeff_shape);
       SubArray<D, T, DeviceType> correction = w;
       correction.resize(coarse_shape);
@@ -156,7 +156,7 @@ void recompose_single(Hierarchy<D, T, DeviceType> &hierarchy,
       SubArray<D, T, DeviceType> coarse = v;
       coarse.resize(coarse_shape);
       SubArray<D, T, DeviceType> coeff = v;
-      coeff.offset(curr_dim, hierarchy.level_shape(l - 1, curr_dim));
+      coeff.offset_dim(curr_dim, hierarchy.level_shape(l - 1, curr_dim));
       coeff.resize(coeff_shape);
       SubArray<D, T, DeviceType> correction = w;
       correction.resize(coarse_shape);

--- a/include/mgard-x/DomainDecomposer/DomainDecomposer.hpp
+++ b/include/mgard-x/DomainDecomposer/DomainDecomposer.hpp
@@ -8,6 +8,9 @@
 #ifndef MGARD_X_DOMAIN_DECOMPOSER_HPP
 #define MGARD_X_DOMAIN_DECOMPOSER_HPP
 
+#include "../Config/Config.h"
+#include "../Hierarchy/Hierarchy.hpp"
+
 namespace mgard_x {
 
 enum class subdomain_copy_direction : uint8_t {
@@ -55,8 +58,9 @@ public:
   bool need_domain_decomposition(std::vector<SIZE> shape,
                                  bool enable_prefetch) {
     size_t estm = estimate_memory_usgae(shape, 1.0, enable_prefetch);
-    size_t aval = std::min(DeviceRuntime<DeviceType>::GetAvailableMemory(),
-                           config.max_memory_footprint);
+    size_t aval =
+        std::min((SIZE)DeviceRuntime<DeviceType>::GetAvailableMemory(),
+                 config.max_memory_footprint);
     log::info("Estimated memory usage: " + std::to_string((double)estm / 1e9) +
               "GB, Available: " + std::to_string((double)aval / 1e9) + "GB");
     return estm >= aval;

--- a/include/mgard-x/DomainDecomposer/DomainDecomposer.hpp
+++ b/include/mgard-x/DomainDecomposer/DomainDecomposer.hpp
@@ -30,7 +30,7 @@ public:
     // log::info("hierarchy_space: " +
     //           std::to_string((double)hierarchy_space / 1e9));
 
-    size_t input_space = roundup(shape[D - 1] * sizeof(T), pitch_size);
+    size_t input_space = roundup((size_t)shape[D - 1] * sizeof(T), pitch_size);
     for (DIM d = 0; d < D - 1; d++) {
       input_space *= shape[d];
     }

--- a/include/mgard-x/MDR-X/Reconstructor/ComposedReconstructor.hpp
+++ b/include/mgard-x/MDR-X/Reconstructor/ComposedReconstructor.hpp
@@ -93,7 +93,8 @@ public:
     size_t partial_data_size = 1;
     for (DIM d = 0; d < D; d++) {
       if (d == D - 1) {
-        partial_data_size *= roundup((shape[d]) * sizeof(T_data), pitch_size);
+        partial_data_size *=
+            roundup((size_t)(shape[d]) * sizeof(T_data), pitch_size);
       } else {
         partial_data_size *= shape[d];
       }

--- a/include/mgard-x/RuntimeX/DataStructures/SubArray.hpp
+++ b/include/mgard-x/RuntimeX/DataStructures/SubArray.hpp
@@ -94,7 +94,7 @@ public:
   void resize(std::vector<SIZE> shape);
 
   MGARDX_CONT
-  void offset(DIM dim, SIZE offset_value);
+  void offset_dim(DIM dim, SIZE offset_value);
 
   MGARDX_CONT
   void resize(DIM dim, SIZE new_size);
@@ -138,15 +138,15 @@ public:
     dv += calc_offset(idx);
   }
 
-  MGARDX_EXEC void offset(IDX z, IDX y, IDX x) {
+  MGARDX_EXEC void offset_3d(IDX z, IDX y, IDX x) {
     ptr_offset += __lddv2 * __lddv1 * z + __lddv1 * y + x;
     dv += __lddv2 * __lddv1 * z + __lddv1 * y + x;
   }
-  MGARDX_EXEC void offset(IDX y, IDX x) {
+  MGARDX_EXEC void offset_2d(IDX y, IDX x) {
     ptr_offset += __lddv1 * y + x;
     dv += __lddv1 * y + x;
   }
-  MGARDX_EXEC void offset(IDX x) {
+  MGARDX_EXEC void offset_1d(IDX x) {
     ptr_offset += x;
     dv += x;
   }
@@ -335,8 +335,8 @@ MGARDX_CONT void SubArray<D, T, DeviceType>::resize(std::vector<SIZE> shape) {
 }
 
 template <DIM D, typename T, typename DeviceType>
-MGARDX_CONT void SubArray<D, T, DeviceType>::offset(DIM dim,
-                                                    SIZE offset_value) {
+MGARDX_CONT void SubArray<D, T, DeviceType>::offset_dim(DIM dim,
+                                                        SIZE offset_value) {
   if (dim >= D)
     return;
   SIZE idx[D];

--- a/include/mgard-x/RuntimeX/Utilities/OffsetCalculators.hpp
+++ b/include/mgard-x/RuntimeX/Utilities/OffsetCalculators.hpp
@@ -10,12 +10,6 @@
 
 namespace mgard_x {
 
-MGARDX_CONT_EXEC LENGTH get_idx(const SIZE ld1, const SIZE ld2, const SIZE z,
-                                const SIZE y, const SIZE x) {
-  return ld2 * ld1 * z + ld1 * y + x;
-}
-
-// for 3D+
 MGARDX_CONT_EXEC LENGTH get_idx(const LENGTH ld1, const LENGTH ld2,
                                 const SIZE z, const SIZE y, const SIZE x) {
   return ld2 * ld1 * z + ld1 * y + x;

--- a/include/mgard-x/RuntimeX/Utilities/SubArrayPrinter.hpp
+++ b/include/mgard-x/RuntimeX/Utilities/SubArrayPrinter.hpp
@@ -280,8 +280,8 @@ void CompareSubarray4D(SubArrayType subArray1, SubArrayType subArray2) {
     SubArrayType temp1 = subArray1;
     SubArrayType temp2 = subArray2;
     // Adding offset to the 4th dim. (slowest)
-    temp1.offset(0, i);
-    temp2.offset(0, i);
+    temp1.offset_dim(0, i);
+    temp2.offset_dim(0, i);
     // Make 3D slice on the other three dims
     CompareSubarray("4D = " + std::to_string(i), temp1.Slice3D(1, 2, 3),
                     temp2.Slice3D(1, 2, 3));
@@ -303,7 +303,7 @@ void PrintSubarray4D(std::string name, SubArrayType subArray1) {
   for (SIZE i = 0; i < subArray1.shape(D - 4); i++) {
     idx[3] = i;
     SubArrayType temp1 = subArray1;
-    temp1.offset(3, i);
+    temp1.offset_dim(3, i);
     PrintSubarray("i = " + std::to_string(i), temp1.Slice3D(0, 1, 2));
   }
 }


### PR DESCRIPTION
When compiling MGARD with Xcode (version 12.4), I found several places where the clang compiler was generating errors because it could not properly resolve overloaded functions/methods. These changes allow the clang compiler to correctly compile MGARD again.