### PR TITLE
`ErrorCalculator.h`: Add Includes

### DIFF
--- a/include/mgard-x/Utilities/ErrorCalculator.h
+++ b/include/mgard-x/Utilities/ErrorCalculator.h
@@ -13,6 +13,11 @@
 // #include "../../shuffle.hpp"
 #include "Types.h"
 
+#include <cmath>
+#include <limits>
+#include <vector>
+
+
 namespace mgard_x {
 
 template <typename T> T L_inf_norm(size_t n, const T *data) {


### PR DESCRIPTION
Adding includes of used stdlib functionality to `ErrorCalculator.h`.
Trying to fix #229

This is generally recommended practice for stability of include files. I have not done a systematic check yet but there are tools that can help with this and explain more on the need:
  https://include-what-you-use.org