### PR TITLE
Fix reference to HIP point attribute structure

### DIFF
--- a/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
+++ b/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
@@ -928,7 +928,7 @@ public:
     log::dbg("Calling MemoryManager<HIP>::IsDevicePointer");
     hipPointerAttribute_t attr;
     hipPointerGetAttributes(&attr, ptr);
-    return attr.memoryType == hipMemoryTypeDevice;
+    return attr.type == hipMemoryTypeDevice;
   }
 
   template <typename T> MGARDX_CONT static int GetPointerDevice(T *ptr) {


### PR DESCRIPTION
When checking whether a pointer is on a HIP device, the previous code had an incorrect name for the member of the `hipPointerAttribute_t` structure. The code is changed to use the correct identifier for this member.