### PR TITLE
Correct type for AbsMax reduction in HIP

### DIFF
--- a/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
+++ b/include/mgard-x/RuntimeX/DeviceAdapters/DeviceAdapterHip.h
@@ -2341,7 +2341,8 @@ public:
     AbsMaxOp absMaxOp;
     hipStream_t stream = DeviceRuntime<HIP>::GetQueue(queue_idx);
     hipcub::DeviceReduce::Reduce(d_temp_storage, temp_storage_bytes, v.data(),
-                                 result.data(), n, absMaxOp, 0, stream);
+                                 result.data(), n, absMaxOp, static_cast<T>(0),
+                                 stream);
     ErrorAsyncCheck(hipGetLastError(), "DeviceCollective<HIP>::AbsMax");
     if (DeviceRuntime<HIP>::SyncAllKernelsAndCheckErrors) {
       ErrorSyncCheck(hipDeviceSynchronize(), "DeviceCollective<HIP>::AbsMax");


### PR DESCRIPTION
The hip device collective for AbsMax does a reduction operation. The initial value was set to a literal int 0, which is wrong for floating types of arrays. This could cause wrong results or compile errors.

Fixes #241