### PR TITLE
Fix build with 3rd party programs when using HIP

### DIFF
--- a/build_scripts/build_mgard_adios2_hip_frontier.sh
+++ b/build_scripts/build_mgard_adios2_hip_frontier.sh
@@ -9,18 +9,18 @@
 set -e
 set -x
 
-module load rocm/5.5.1
+module load rocm/6.3.1
 module load cmake
 
 ######## User Configurations ########
 # Source directory
 mgard_x_src_dir=.
 # Build directory
-build_dir=./build-hip-crusher
+build_dir=./build-hip-frontier-adios2
 # Number of processors used for building
 num_build_procs=$1
 # Installtaion directory
-install_dir=./install-hip-crusher
+install_dir=./install-hip-frontier-adios2
 
 export LD_LIBRARY_PATH=$(pwd)/${install_dir}/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$(pwd)/${install_dir}/lib64:$LD_LIBRARY_PATH

--- a/build_scripts/build_mgard_hip_frontier.sh
+++ b/build_scripts/build_mgard_hip_frontier.sh
@@ -9,7 +9,7 @@
 set -e
 set -x
 
-module load rocm/5.5.1
+module load rocm/6.3.1
 module load cmake
 
 ######## User Configurations ########

--- a/cmake/mgard-config.cmake.in
+++ b/cmake/mgard-config.cmake.in
@@ -23,6 +23,21 @@ if(@CUDAToolkit_FOUND@)
 	list(APPEND REQUIRED_VARS CUDAToolkit_FOUND)
 endif()
 
+if(@HIP_FOUND@)
+	find_dependency(HIP)
+	list(APPEND REQUIRED_VARS HIP_FOUND)
+endif()
+
+if(@rocprim_FOUND@)
+	find_dependency(rocprim)
+	list(APPEND REQUIRED_VARS rocprim_FOUND)
+endif()
+
+if(@hipcub_FOUND@)
+	find_dependency(hipcub)
+	list(APPEND REQUIRED_VARS hipcub_FOUND)
+endif()
+
 if(@MOAB_FOUND@)
 	find_dependency(MOAB)
 	list(APPEND REQUIRED_VARS MOAB_FOUND)


### PR DESCRIPTION
Fix build/linking issues with third-party programs when MGARD was built with HIP. This fix is necessary after new dependencies ```hipcub``` and ```hipcub``` were introduced in #239. 