### PR TITLE
Make hipCUB dependency privacy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,9 +218,9 @@ if (MGARD_ENABLE_HIP)
   # is because different sources require different compilers. So, instead just
   # grab the include directories.
   target_include_directories(mgard-library
-    PUBLIC $<TARGET_PROPERTY:hip::hipcub,INTERFACE_INCLUDE_DIRECTORIES>
-    PUBLIC $<TARGET_PROPERTY:roc::rocprim_hip,INTERFACE_INCLUDE_DIRECTORIES>
-    PUBLIC $<TARGET_PROPERTY:roc::rocprim,INTERFACE_INCLUDE_DIRECTORIES>
+    PRIVATE $<TARGET_PROPERTY:hip::hipcub,INTERFACE_INCLUDE_DIRECTORIES>
+    PRIVATE $<TARGET_PROPERTY:roc::rocprim_hip,INTERFACE_INCLUDE_DIRECTORIES>
+    PRIVATE $<TARGET_PROPERTY:roc::rocprim,INTERFACE_INCLUDE_DIRECTORIES>
     )
 endif()
 


### PR DESCRIPTION
When compiling with HIP, there is a hipCUB dependency. For reasons, you cannot load the library directly. Instead, we add the include directories to the library. These were declared public, but other projects importing the library would not necessarily have these dependent libraries. Thus, declare them private. They should only be needed when compiling the MGARD library.