### PR TITLE
Fix defines created by CMake configure_file

### DIFF
--- a/include/MGARDXConfig.h.in
+++ b/include/MGARDXConfig.h.in
@@ -8,52 +8,20 @@
 #ifndef MGARD_X_CONFIG_H
 #define MGARD_X_CONFIG_H
 
-#if '@MGARD_ENABLE_SERIAL@' == 'ON'
-#define MGARD_ENABLE_SERIAL 1
-#else
-#define MGARD_ENABLE_SERIAL 0   
-#endif
+#cmakedefine01 MGARD_ENABLE_SERIAL
 
-#if '@MGARD_ENABLE_OPENMP@' == 'ON'
-#define MGARD_ENABLE_OPENMP 1
-#else
-#define MGARD_ENABLE_OPENMP 0   
-#endif
+#cmakedefine01 MGARD_ENABLE_OPENMP
 
-#if '@MGARD_ENABLE_CUDA@' == 'ON'
-#define MGARD_ENABLE_CUDA 1
-#else
-#define MGARD_ENABLE_CUDA 0   
-#endif
+#cmakedefine01 MGARD_ENABLE_CUDA
 
-#if '@MGARD_ENABLE_HIP@' == 'ON'
-#define MGARD_ENABLE_HIP 1
-#else
-#define MGARD_ENABLE_HIP 0   
-#endif
+#cmakedefine01 MGARD_ENABLE_HIP
 
-#if '@MGARD_ENABLE_SYCL@' == 'ON'
-#define MGARD_ENABLE_SYCL 1
-#else
-#define MGARD_ENABLE_SYCL 0   
-#endif
+#cmakedefine01 MGARD_ENABLE_SYCL
 
-#if '@MGARD_ENABLE_LEGACY_CUDA@' == 'ON'
-#define MGARD_ENABLE_LEGACY_CUDA 1
-#else
-#define MGARD_ENABLE_LEGACY_CUDA 0   
-#endif
+#cmakedefine01 MGARD_ENABLE_LEGACY_CUDA
 
-#if '@MGARD_ENABLE_AUTO_TUNING@' == 'ON'
-#define MGARD_ENABLE_AUTO_TUNING 1
-#else
-#define MGARD_ENABLE_AUTO_TUNING 0   
-#endif
+#cmakedefine01 MGARD_ENABLE_AUTO_TUNING
 
-#if '@MGARD_ENABLE_EXTERNAL_COMPRESSOR@' == 'ON'
-#define MGARD_ENABLE_EXTERNAL_COMPRESSOR 1
-#else
-#define MGARD_ENABLE_EXTERNAL_COMPRESSOR 0   
-#endif
+#cmakedefine01 MGARD_ENABLE_EXTERNAL_COMPRESSOR
 
 #endif

--- a/include/mgard-x/RuntimeX/RuntimeX.h
+++ b/include/mgard-x/RuntimeX/RuntimeX.h
@@ -20,6 +20,8 @@
 // Serial backend should be always available
 #if MGARD_ENABLE_SERIAL
 #include "DeviceAdapters/DeviceAdapterSerial.h"
+#else
+#error "The serial MGARD device should always be available."
 #endif
 
 #if MGARD_ENABLE_OPENMP


### PR DESCRIPTION
Recent versions of CMake must have changed how variables created from `option` commands were substituted in the `configure_file` command. Previously, they substituted to `ON` or `OFF`, but now they substitute for `TRUE` or `FALSE`. This causes a problem with how MGARDXConfig.h matched strings to set the `MGARD_ENABLE_X` macros.

This change replaces string substitution with `#cmakedefine01`, which will simply replace the statement with a `#define` setting the variable to either 0 or 1, which is the desired outcome.